### PR TITLE
chore: fetch personal pp and remove notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,3 @@ open http://localhost:8080
 #### Mobile
 
 ![screenshot 2](https://github.com/ubiquity/devpool-directory-ui/assets/4975670/b7861ce7-1f1f-49a9-b8e2-ebb20724ee67)
-

--- a/src/home/fetch-github/fetch-and-display-previews.ts
+++ b/src/home/fetch-github/fetch-and-display-previews.ts
@@ -24,7 +24,7 @@ export async function fetchAndDisplayPreviewsFromCache(sorting?: Sorting, option
     };
   }
 
-  const cachedTasks = _cachedTasks.tasks.map((task) => ({ ...task, isNew: false, isModified: false })) as TaskMaybeFull[];
+  const cachedTasks = _cachedTasks.tasks as TaskMaybeFull[];
   taskManager.syncTasks(cachedTasks);
 
   if (!cachedTasks.length) {
@@ -73,8 +73,7 @@ export function verifyGitHubIssueState(cachedTasks: TaskMaybeFull[], fetchedPrev
     if (cachedTask) {
       if (taskWithFullTest(cachedTask)) {
         const cachedFullIssue = cachedTask.full;
-        const isModified = new Date(cachedFullIssue.updated_at) < new Date(fetched.preview.updated_at);
-        const task = { ...fetched, full: cachedFullIssue, isModified };
+        const task = { ...fetched, full: cachedFullIssue };
         return task;
       } else {
         // no full issue in task
@@ -84,8 +83,6 @@ export function verifyGitHubIssueState(cachedTasks: TaskMaybeFull[], fetchedPrev
     }
     return {
       preview: fetched.preview,
-      isNew: true,
-      isModified: false,
     } as TaskNoFull;
   });
 }

--- a/src/home/fetch-github/fetch-and-display-previews.ts
+++ b/src/home/fetch-github/fetch-and-display-previews.ts
@@ -14,8 +14,6 @@ export type Options = {
   ordering: "normal" | "reverse";
 };
 
-const NOTIFICATION_EXPIRY_DAYS = 3;
-
 export async function fetchAndDisplayPreviewsFromCache(sorting?: Sorting, options = { ordering: "normal" }) {
   let _cachedTasks = getLocalStore(GITHUB_TASKS_STORAGE_KEY) as TaskStorageItems;
   // makes sure tasks have a timestamp to know how old the cache is, or refresh if older than 15 minutes
@@ -24,21 +22,17 @@ export async function fetchAndDisplayPreviewsFromCache(sorting?: Sorting, option
       timestamp: Date.now(),
       tasks: [],
     };
-  } else {
-    const cachedTasks = _cachedTasks.tasks.map((task) => ({
-      ...task,
-      isNew: new Date(task.preview.created_at) > new Date(Date.now() - 1000 * 60 * 60 * 24 * NOTIFICATION_EXPIRY_DAYS),
-      isModified: false,
-    })) as TaskMaybeFull[];
-    taskManager.syncTasks(cachedTasks);
+  }
 
-    if (!cachedTasks.length) {
-      // load from network if there are no cached issues
-      return fetchAndDisplayPreviewsFromNetwork(sorting, options);
-    } else {
-      displayGitHubIssues(sorting, options);
-      return fetchAvatars();
-    }
+  const cachedTasks = _cachedTasks.tasks.map((task) => ({ ...task, isNew: false, isModified: false })) as TaskMaybeFull[];
+  taskManager.syncTasks(cachedTasks);
+
+  if (!cachedTasks.length) {
+    // load from network if there are no cached issues
+    return fetchAndDisplayPreviewsFromNetwork(sorting, options);
+  } else {
+    displayGitHubIssues(sorting, options);
+    return fetchAvatars();
   }
 }
 

--- a/src/home/fetch-github/fetch-avatar.ts
+++ b/src/home/fetch-github/fetch-avatar.ts
@@ -39,5 +39,21 @@ export async function fetchAvatar(orgName: string) {
     }
   } catch (error) {
     console.error(`Failed to fetch avatar for organization ${orgName}: ${error}`);
+    const {
+      data: { avatar_url: avatarUrl },
+    } = await octokit.rest.users.getByUsername({ username: orgName });
+    if (avatarUrl) {
+      // Fetch the image as a Blob and save it to IndexedDB
+      const response = await fetch(avatarUrl);
+      const blob = await response.blob();
+      await saveImageToCache({
+        dbName: "GitHubAvatars",
+        storeName: "ImageStore",
+        keyName: "name",
+        orgName: `avatarUrl-${orgName}`,
+        avatarBlob: blob,
+      });
+      organizationImageCache.set(orgName, blob);
+    }
   }
 }

--- a/src/home/getters/get-local-store.ts
+++ b/src/home/getters/get-local-store.ts
@@ -17,16 +17,5 @@ export function getLocalStore(key: string): TaskStorageItems | OAuthToken | null
 
 export function setLocalStore(key: string, value: TaskStorageItems | OAuthToken) {
   // remove state from issues before saving to local storage
-  if ("tasks" in value && value.tasks.length && "isNew" in value.tasks[0] && "isModified" in value.tasks[0]) {
-    const tasksWithoutState = value.tasks.map(({ preview, full }) => ({
-      preview,
-      full,
-    }));
-    localStorage[key] = JSON.stringify({
-      ...value,
-      tasks: tasksWithoutState,
-    });
-  } else {
-    localStorage[key] = JSON.stringify(value);
-  }
+  localStorage[key] = JSON.stringify(value);
 }

--- a/src/home/rendering/render-github-issues.ts
+++ b/src/home/rendering/render-github-issues.ts
@@ -37,13 +37,6 @@ function everyNewIssue({ taskPreview, container }: { taskPreview: TaskMaybeFull;
   issueElement.setAttribute("data-preview-id", taskPreview.preview.id.toString());
   issueElement.classList.add("issue-element-inner");
 
-  if (taskPreview.isNew) {
-    issueWrapper.classList.add("new-task");
-  }
-  if (taskPreview.isModified) {
-    issueWrapper.classList.add("modified-task");
-  }
-
   const urlPattern = /https:\/\/github\.com\/([^/]+)\/([^/]+)\//;
   const match = taskPreview.preview.body.match(urlPattern);
   const organizationName = match?.[1];

--- a/static/style/inverted-style.css
+++ b/static/style/inverted-style.css
@@ -321,23 +321,6 @@
   .full {
     display: unset !important;
   }
-  .new-task,
-  .modified-task {
-    position: relative;
-  }
-  .new-task::before,
-  .modified-task::before {
-    content: "";
-    display: inline-block;
-    position: absolute;
-    height: 100%;
-    width: 4px;
-    left: 0;
-    background-color: #00ffff;
-  }
-  .modified-task::before {
-    background-color: #ffff00;
-  }
   @media screen and (max-width: 804px) {
     .mid {
       display: none !important;

--- a/static/style/inverted-style.css
+++ b/static/style/inverted-style.css
@@ -180,6 +180,9 @@
     display: flex;
     align-items: center;
     height: 16px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: inline-block;
   }
   input[type="radio"] {
     background-color: unset;

--- a/static/style/style.css
+++ b/static/style/style.css
@@ -321,23 +321,6 @@
   .full {
     display: unset !important;
   }
-  .new-task,
-  .modified-task {
-    position: relative;
-  }
-  .new-task::before,
-  .modified-task::before {
-    content: "";
-    display: inline-block;
-    position: absolute;
-    height: 100%;
-    width: 4px;
-    left: 0;
-    background-color: #0ff;
-  }
-  .modified-task::before {
-    background-color: #ff0;
-  }
   @media screen and (max-width: 804px) {
     .mid {
       display: none !important;

--- a/static/style/style.css
+++ b/static/style/style.css
@@ -180,6 +180,9 @@
     display: flex;
     align-items: center;
     height: 16px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: inline-block;
   }
   input[type="radio"] {
     background-color: unset;


### PR DESCRIPTION
Resolves #21 

- failing to fetch the org pp will fetch from the users endpoint
- added ``NOTIFICATION_EXPIRY_DAYS = 3`` 
- it seemed that previously the ``isNew`` prop was being wiped after it experienced it's first cache refresh, this way it's based on the ``created_at`` which seems like a better approach

The timeframe looks a little squished when it's at defcon 1 don't you think?

![image](https://github.com/ubiquity/work.ubq.fi/assets/106303466/736be60c-d6ca-4dfc-9f2b-0fb7cb2824cb)
