### PR TITLE
fix: cypress test for GitHub login do not try to revalidate the app

### DIFF
--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -2,8 +2,6 @@ name: Run Cypress testing suite
 on:
   workflow_dispatch:
   push:
-    branches:
-      - development
 
 jobs:
   cypress-run:

--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -1,8 +1,9 @@
 name: Run Cypress testing suite
 on:
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize]
+  push:
+    branches:
+      - development
 
 jobs:
   cypress-run:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ static/dist
 .env
 
 cypress/screenshots
+cypress/videos

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -16,4 +16,5 @@ export default defineConfig({
     GITHUB_PASSWORD: process.env.UBIQUIBOT_GITHUB_PASSWORD,
   },
   watchForFileChanges: false,
+  video: true,
 });

--- a/cypress/e2e/devpool.cy.ts
+++ b/cypress/e2e/devpool.cy.ts
@@ -123,14 +123,18 @@ describe("DevPool", () => {
       cy.get("#login_field").type(Cypress.env("GITHUB_USERNAME"));
       cy.get("#password").type(Cypress.env("GITHUB_PASSWORD"));
       cy.get(".position-relative > .btn").click();
-      cy.get('button[data-octo-click="oauth_application_authorization"]').then(($button) => {
-        // This happens when too many requests are done to log in, it asks again for verification.
-        if ($button.is(":visible")) {
-          cy.wrap($button).click();
-        } else {
-          cy.log('"Authorize" button is not visible');
-        }
-      });
+      // This part of the test can sometimes fail if the endpoint for OAuth is hit too many times, asking the user to
+      // authorize the app again. It should not happen in a normal testing scenario since it's only hit once, but more
+      // commonly happens in local testing where the test can be run many times in a row. Uncomment this part to add
+      // the authorization of the app again.
+
+      // cy.get('button[data-octo-click="oauth_application_authorization"]').then(($button) => {
+      //   if ($button.is(":visible")) {
+      //     cy.wrap($button).click();
+      //   } else {
+      //     cy.log('"Authorize" button is not visible');
+      //   }
+      // });
     });
     cy.get("#authenticated").should("exist");
     cy.get("#filter").should("be.visible");

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",
-    "cypress": "13.6.5",
+    "cypress": "13.7.0",
     "esbuild": "^0.19.8",
     "eslint": "^8.54.0",
     "eslint-config-prettier": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,10 +1522,10 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
-cypress@13.6.5:
-  version "13.6.5"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.6.5.tgz#d8ab22dda3b9a8abeebcb65dc8a2707cb73bf925"
-  integrity sha512-2NxSDcO2zHw5kTcosc6dzv2zppEqiXrFFhZw5cx/EWrSNZABTzpr/EyvYzGgrWm46o5173JUfuJfDQcaiZZPVQ==
+cypress@13.7.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.7.0.tgz#19e53c0bd6eca5e3bde0d6ac9e98fbf1782e3a9e"
+  integrity sha512-UimjRSJJYdTlvkChcdcfywKJ6tUYuwYuk/n1uMMglrvi+ZthNhoRYcxnWgTqUtkl17fXrPAsD5XT2rcQYN1xKA==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"
@@ -4306,7 +4306,16 @@ string-argv@0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4381,7 +4390,14 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4861,7 +4877,7 @@ which@^4.0.0:
   dependencies:
     isexe "^3.1.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -4874,6 +4890,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This PR aims to solve issues encountered when running Cypress for the login test step.

The main issue is that GitHub rate limits users on how many times they can hit the login endpoint. If too many tests are run, the redirect doesn't happen on login and instead asks the user to revalidate the app. A case was made for this workflow, but after testing more thoroughly I saw that GitHub has a hard limit as shown in the screenshot 
![image](https://github.com/ubiquity/work.ubq.fi/assets/9807008/b9cf4ec2-1cfb-4473-924e-150cb2c0526d)

I don't think there is any workaround on this, since we have no control other those limits. It is not possible to fake an OAuth except if we run all locally (very unlikely scenario). I think this would not happen often if users try locally with their own account, since the Cypress tests will run once in a while and not every 2 seconds. So this scenario should (hopefully) be unlikely to happen. Still, few measures were taken:

- enabling Cypress videos to help debugging
- add an explicit comment and the necessary code to solve the issue when the rate limit is exceeded
- updated Cypress to the latest version
- changed Cypress trigger to be pushes to the `development` branch as I know @rndquu is eager to remove the `pull_request_target` events

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
