### PR TITLE
feat: track devRel referrals with google analytics

### DIFF
--- a/src/home/authentication.ts
+++ b/src/home/authentication.ts
@@ -1,3 +1,4 @@
+import { trackDevRelReferral } from "./devrel-tracker";
 import { getGitHubAccessToken } from "./getters/get-github-access-token";
 import { getGitHubUser } from "./getters/get-github-user";
 import { GitHubUser } from "./github-types";
@@ -12,6 +13,7 @@ export async function authentication() {
 
   const gitHubUser: null | GitHubUser = await getGitHubUser();
   if (gitHubUser) {
+    trackDevRelReferral(gitHubUser.name as string);
     displayGitHubUserInformation(gitHubUser);
   }
 }

--- a/src/home/devrel-tracker.ts
+++ b/src/home/devrel-tracker.ts
@@ -1,0 +1,22 @@
+export function initiateDevRelTracking() {
+  const oldDevRelCode = localStorage.getItem("devRel");
+  if (!oldDevRelCode) {
+    const urlParams = new URLSearchParams(window.location.search);
+    const devRelCode = urlParams.get("devRel");
+    if (devRelCode) {
+      localStorage.setItem("devRel", devRelCode);
+    }
+  }
+}
+
+export function trackDevRelReferral(devGithub: string) {
+  const devRelCode = localStorage.getItem("devRel");
+  if (devRelCode && devRelCode != "done") {
+    // @ts-expect-error : using global gtag
+    gtag("event", "ethSeoul_registration", {
+      devRel: devRelCode,
+      devGithub: devGithub,
+    });
+    localStorage.setItem("devRel", "done");
+  }
+}

--- a/src/home/home.ts
+++ b/src/home/home.ts
@@ -1,11 +1,13 @@
 import { grid } from "../the-grid";
 import { authentication } from "./authentication";
+import { initiateDevRelTracking } from "./devrel-tracker";
 import { fetchAndDisplayPreviewsFromCache } from "./fetch-github/fetch-and-display-previews";
 import { fetchIssuesFull } from "./fetch-github/fetch-issues-full";
 import { readyToolbar } from "./ready-toolbar";
 import { generateSortingToolbar } from "./sorting/generate-sorting-buttons";
 import { TaskManager } from "./task-manager";
 
+initiateDevRelTracking();
 generateSortingToolbar();
 renderServiceMessage();
 grid(document.getElementById("grid") as HTMLElement, () => document.body.classList.add("grid-loaded")); // @DEV: display grid background

--- a/static/index.html
+++ b/static/index.html
@@ -4,6 +4,18 @@
     <meta charset="UTF-8" />
     <title>DevPool Directory | Ubiquity DAO</title>
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VZLJ61H1YM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-VZLJ61H1YM");
+    </script>
+
     <link rel="stylesheet" href="style/style.css" />
     <link rel="stylesheet" href="style/inverted-style.css" />
     <link rel="stylesheet" href="style/special.css" />


### PR DESCRIPTION
Resolves #30

This should be merged ASAP so that we can test google analytics receiving events. Because my test domain was different than the production domain. 

The link is going to be something like `https://work.ubq.fi/?devRel=XYZ` where `XYZ` is the code you want to give to DevRel. This code can't be the word `done` because it has a special meaning in code. 

There are some things I want to refactor like: 
- moving the measurement id of Google Analytics to configs
- getting rid of `@ts-expect-error` on the use of gtag()

But I am very tired and out of energy right now. Google Analytics gave me a tough time and I am still not fully satisfied with its results. 

Right now the foucs should be on testing it. Making it work in the conference. Any refactoring you want can be done in the next PR, leave comments for that.

QA:

I am hoping to get something like this out of Google Analytics: 

![image](https://github.com/ubiquity/work.ubq.fi/assets/11886219/1128dc7b-37bb-45ab-9c1e-c76a2d1ccb2d)

This is from yesterday's data. It is bad and it is what I could get, and I was hoping to get a better report of today's data but I will access to that data tomorrow in Google Analytics Explore. 

The only thing that gives me a little confidence is the event being received by Google Analytics with correct data. We can hope to give it a better shape. 

![Screenshot_20240323_221538](https://github.com/ubiquity/work.ubq.fi/assets/11886219/a8d5bc13-b33d-4a40-a051-225eff076eec)


<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
