### PR TITLE
fix:  replace github name with login+id for referral

### DIFF
--- a/src/home/authentication.ts
+++ b/src/home/authentication.ts
@@ -13,7 +13,7 @@ export async function authentication() {
 
   const gitHubUser: null | GitHubUser = await getGitHubUser();
   if (gitHubUser) {
-    trackDevRelReferral(gitHubUser.name as string);
+    trackDevRelReferral(gitHubUser.login + "|" + gitHubUser.id);
     displayGitHubUserInformation(gitHubUser);
   }
 }


### PR DESCRIPTION
Improves https://github.com/ubiquity/work.ubq.fi/issues/30

We were catching github name of referral which is optional in github.  See No.7 below. This PR makes the analytics use github login + github id instead of github name. 

![image](https://github.com/ubiquity/work.ubq.fi/assets/11886219/5614d0d6-8406-4c84-93e4-4bcc5a076542)






<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
