### PR TITLE
fix:empty directory page after logged in for the first time

### DIFF
--- a/src/home/fetch-github/fetch-and-display-previews.ts
+++ b/src/home/fetch-github/fetch-and-display-previews.ts
@@ -58,7 +58,7 @@ export async function fetchAndDisplayPreviewsFromNetwork(sorting?: Sorting, opti
   const updatedCachedIssues = verifyGitHubIssueState(cachedTasks, fetchedPreviews);
   taskManager.syncTasks(updatedCachedIssues);
   displayGitHubIssues(sorting, options);
-  await taskManager.writeToStorage()
+  await taskManager.writeToStorage();
   return fetchAvatars();
 }
 

--- a/src/home/fetch-github/fetch-and-display-previews.ts
+++ b/src/home/fetch-github/fetch-and-display-previews.ts
@@ -36,7 +36,7 @@ export async function fetchAndDisplayPreviewsFromCache(sorting?: Sorting, option
     _cachedTasks = {
       timestamp: Date.now(),
       tasks: [],
-      loggedIn: _accessToken !== null,
+      loggedIn: !!_accessToken,
     };
   }
 
@@ -58,6 +58,7 @@ export async function fetchAndDisplayPreviewsFromNetwork(sorting?: Sorting, opti
   const updatedCachedIssues = verifyGitHubIssueState(cachedTasks, fetchedPreviews);
   taskManager.syncTasks(updatedCachedIssues);
   displayGitHubIssues(sorting, options);
+  await taskManager.writeToStorage()
   return fetchAvatars();
 }
 

--- a/src/home/fetch-github/fetch-issues-preview.ts
+++ b/src/home/fetch-github/fetch-issues-preview.ts
@@ -30,7 +30,6 @@ async function checkPrivateRepoAccess(): Promise<boolean> {
       } else {
         // Handle other errors if needed
         console.error("Error checking repository access:", error);
-        throw error;
       }
     }
   }

--- a/src/home/home.ts
+++ b/src/home/home.ts
@@ -27,8 +27,6 @@ void (async function home() {
     const previews = await fetchAndDisplayPreviewsFromCache();
     const fullTasks = await fetchIssuesFull(previews);
     taskManager.syncTasks(fullTasks);
-    console.trace({ fullTasks });
-    await taskManager.writeToStorage();
     return fullTasks;
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
Resolves #47

Here's a concise pull request description for the changes you've made:

**Description:**
This pull request addresses an issue in the `fetchIssuePreviews` function where an error thrown by `checkPrivateRepoAccess` would prevent the population of the `freshIssues` array. The error handling logic was prematurely exiting the function, resulting in an empty array being returned.

Here's a rundown of what happens in the `fetchIssuePreview` function 


```js 
async function fetchIssuePreviews() {
  let freshIssues = [];
  try {
    // This will throw an error if the condition in checkPrivateRepoAccess's catch block is not met
    hasPrivateRepoAccess = await checkPrivateRepoAccess();
    // Code to populate freshIssues does not run, it moves directly to the catch block below...
  } catch (error) {
    // Error handling...
    // Since an error was thrown, freshIssues remains empty
  }
  // Returns tasks based on the empty freshIssues array
  return freshIssues.map(/* ... */);
}
```

Changes:
- Removed the `throw error` line in the `checkPrivateRepoAccess` function's `catch` block.
- This ensures that even if an error occurs, the `fetchIssuePreviews` function can continue to execute and populate `freshIssues` with issues from the public repository.
