### PR TITLE
feat: optimize avatar fetching from GitHub API and avatar storing as well

### DIFF
--- a/src/home/fetch-github/fetch-and-display-previews.ts
+++ b/src/home/fetch-github/fetch-and-display-previews.ts
@@ -1,5 +1,4 @@
 import { getGitHubAccessToken } from "../getters/get-github-access-token";
-import { getImageFromCache } from "../getters/get-indexed-db";
 import { getLocalStore } from "../getters/get-local-store";
 import { GITHUB_TASKS_STORAGE_KEY, GitHubIssue, TaskStorageItems } from "../github-types";
 import { taskManager } from "../home";
@@ -7,7 +6,6 @@ import { applyAvatarsToIssues, renderGitHubIssues } from "../rendering/render-gi
 import { Sorting } from "../sorting/generate-sorting-buttons";
 import { sortIssuesController } from "../sorting/sort-issues-controller";
 import { fetchAvatar } from "./fetch-avatar";
-import { organizationImageCache } from "./fetch-issues-full";
 
 export type Options = {
   ordering: "normal" | "reverse";
@@ -80,18 +78,6 @@ export async function fetchAvatars() {
 
 export function displayGitHubIssues(sorting?: Sorting, options = { ordering: "normal" }) {
   const cached = taskManager.getTasks();
-  cached.forEach(async (gitHubIssue) => {
-    const [orgName] = gitHubIssue.repository_url.split("/").slice(-2);
-
-    getImageFromCache({
-      dbName: "GitHubAvatars",
-      storeName: "ImageStore",
-      orgName: `avatarUrl-${orgName}`,
-    })
-      .then((avatarUrl) => organizationImageCache.set(orgName, avatarUrl))
-      .catch(console.error);
-  });
-
   const sortedIssues = sortIssuesController(cached, sorting, options);
   const sortedAndFiltered = sortedIssues.filter(getProposalsOnlyFilter(isProposalOnlyViewer));
   renderGitHubIssues(sortedAndFiltered);

--- a/src/home/fetch-github/fetch-avatar.ts
+++ b/src/home/fetch-github/fetch-avatar.ts
@@ -4,57 +4,103 @@ import { getImageFromCache, saveImageToCache } from "../getters/get-indexed-db";
 import { renderErrorInModal } from "../rendering/display-popup-modal";
 import { organizationImageCache } from "./fetch-issues-full";
 
-export async function fetchAvatar(orgName: string) {
-  // Check local cache first
+// Map to track ongoing avatar fetches
+const pendingFetches: Map<string, Promise<Blob | void>> = new Map();
+
+export async function fetchAvatar(orgName: string): Promise<Blob | void> {
+  // Check if the avatar is already cached in memory
   const cachedAvatar = organizationImageCache.get(orgName);
   if (cachedAvatar) {
-    return Promise.resolve();
+    console.log(`Returning cached avatar for ${orgName}`);
+    return cachedAvatar;
   }
 
-  // If not in local cache, check IndexedDB
-  const avatarBlob = await getImageFromCache({ dbName: "GitHubAvatars", storeName: "ImageStore", orgName: `avatarUrl-${orgName}` });
-  if (avatarBlob) {
-    // If the avatar Blob is found in IndexedDB, add it to the cache
-    organizationImageCache.set(orgName, avatarBlob);
-    return Promise.resolve();
+  // If there's a pending fetch for this organization, wait for it to complete
+  if (pendingFetches.has(orgName)) {
+    console.log(`Waiting for ongoing fetch for ${orgName}`);
+    return pendingFetches.get(orgName);
   }
 
-  // If not in IndexedDB, fetch from network
-  const octokit = new Octokit({ auth: await getGitHubAccessToken() });
+  // Start the fetch process and store the promise in the pending fetches map
+  const fetchPromise = (async () => {
+    console.log(`Attempting to fetch avatar for ${orgName}`);
+
+    // Step 1: Try to get the avatar from IndexedDB
+    const avatarBlob = await getImageFromCache({ dbName: "GitHubAvatars", storeName: "ImageStore", orgName: `avatarUrl-${orgName}` });
+    if (avatarBlob) {
+      console.log(`Avatar found in IndexedDB for ${orgName}`);
+      organizationImageCache.set(orgName, avatarBlob); // Cache it in memory
+      return avatarBlob;
+    }
+
+    // Step 2: No avatar in IndexedDB, fetch from network
+    const octokit = new Octokit({ auth: await getGitHubAccessToken() });
+
+    try {
+      const {
+        data: { avatar_url: avatarUrl },
+      } = await octokit.rest.orgs.get({ org: orgName });
+
+      if (avatarUrl) {
+        console.log(`Fetching avatar from network for ${orgName}`);
+        const response = await fetch(avatarUrl);
+        const blob = await response.blob();
+
+        // Cache the fetched avatar in both memory and IndexedDB
+        await saveImageToCache({
+          dbName: "GitHubAvatars",
+          storeName: "ImageStore",
+          keyName: "name",
+          orgName: `avatarUrl-${orgName}`,
+          avatarBlob: blob,
+        });
+
+        organizationImageCache.set(orgName, blob);
+        console.log(`Avatar cached for ${orgName}`);
+        return blob;
+      }
+    } catch (error) {
+      renderErrorInModal(error as Error, `Failed to fetch avatar for organization ${orgName}: ${error}`);
+    }
+
+    // Step 3: Try fetching for users if the organization lookup failed
+    try {
+      const {
+        data: { avatar_url: avatarUrl },
+      } = await octokit.rest.users.getByUsername({ username: orgName });
+
+      if (avatarUrl) {
+        console.log("Fetching avatar from network by user", orgName);
+        const response = await fetch(avatarUrl);
+        const blob = await response.blob();
+
+        // Cache the fetched avatar in both memory and IndexedDB
+        await saveImageToCache({
+          dbName: "GitHubAvatars",
+          storeName: "ImageStore",
+          keyName: "name",
+          orgName: `avatarUrl-${orgName}`,
+          avatarBlob: blob,
+        });
+
+        organizationImageCache.set(orgName, blob);
+        console.log(`Avatar cached for user ${orgName}`);
+
+        return blob;
+      }
+    } catch (innerError) {
+      renderErrorInModal(innerError as Error, `Failed to fetch avatar for user ${orgName}: ${innerError}`);
+    }
+  })();
+
+  pendingFetches.set(orgName, fetchPromise);
+
+  // Wait for the fetch to complete
   try {
-    const {
-      data: { avatar_url: avatarUrl },
-    } = await octokit.rest.orgs.get({ org: orgName });
-    if (avatarUrl) {
-      // Fetch the image as a Blob and save it to IndexedDB
-      const response = await fetch(avatarUrl);
-      const blob = await response.blob();
-      await saveImageToCache({
-        dbName: "GitHubAvatars",
-        storeName: "ImageStore",
-        keyName: "name",
-        orgName: `avatarUrl-${orgName}`,
-        avatarBlob: blob,
-      });
-      organizationImageCache.set(orgName, blob);
-    }
-  } catch (error) {
-    renderErrorInModal(error as Error, `Failed to fetch avatar for organization ${orgName}: ${error}`);
-    const {
-      data: { avatar_url: avatarUrl },
-    } = await octokit.rest.users.getByUsername({ username: orgName });
-    if (avatarUrl) {
-      // Fetch the image as a Blob and save it to IndexedDB
-      const response = await fetch(avatarUrl);
-      const blob = await response.blob();
-      await saveImageToCache({
-        dbName: "GitHubAvatars",
-        storeName: "ImageStore",
-        keyName: "name",
-        orgName: `avatarUrl-${orgName}`,
-        avatarBlob: blob,
-      });
-      organizationImageCache.set(orgName, blob);
-    }
+    const result = await fetchPromise;
+    return result;
+  } finally {
+    // Remove the pending fetch once it completes
+    pendingFetches.delete(orgName);
   }
 }


### PR DESCRIPTION
Resolves #105

This allows only a single request for avatar per organization in `cachedTasks`. It works by allowing a single execution of `fetchAvatar(orgName)` to run per `orgName` while others are kept on wait. On resolve all of them share the same cached blob. This also means that a single instance is setting cache. 

I've also removed the unnecessary avatar fetching from DB in `fetch-and-display-preview.ts`, since it's `fetch-avatar.ts`'s single responsibility to do so. By keeping all avatar-related logic within `fetchAvatar`, we ensure a single source of truth for avatar fetching, which simplifies code too.