### PR TITLE
feat: fix flickering on login

### DIFF
--- a/src/home/rendering/display-github-user-information.ts
+++ b/src/home/rendering/display-github-user-information.ts
@@ -34,7 +34,7 @@ export async function displayGitHubUserInformation(gitHubUser: GitHubUser) {
       renderErrorInModal(error, "Error logging out");
       alert("Error logging out");
     }
-    window.location.replace('/');
+    window.location.replace("/");
   });
 
   if (await isOrgMemberWithoutScope()) {

--- a/src/home/rendering/display-github-user-information.ts
+++ b/src/home/rendering/display-github-user-information.ts
@@ -34,7 +34,7 @@ export async function displayGitHubUserInformation(gitHubUser: GitHubUser) {
       renderErrorInModal(error, "Error logging out");
       alert("Error logging out");
     }
-    window.location.reload();
+    window.location.replace('/');
   });
 
   if (await isOrgMemberWithoutScope()) {

--- a/src/home/rendering/render-github-issues.ts
+++ b/src/home/rendering/render-github-issues.ts
@@ -167,8 +167,8 @@ function updateUrlWithIssueId(issueID: number) {
     newURL.searchParams.set("proposal", "true");
   }
 
-  // Push to history
-  window.history.pushState({ issueID }, "", newURL.toString());
+  // Set issue in URL
+  window.history.replaceState({ issueID }, "", newURL.toString());
 }
 
 // Opens the preview modal if a URL contains an issueID
@@ -197,11 +197,6 @@ export function loadIssueFromUrl() {
 
   viewIssueDetails(issue);
 }
-
-// This ensure previews load for the URL
-window.addEventListener("popstate", () => {
-  location.reload();
-});
 
 export function applyAvatarsToIssues() {
   const container = taskManager.getContainer();


### PR DESCRIPTION
This event handler was reloading because callback uses popstate, it's not even a good feature adding issues to URL history so let's just rollback this feat. To be clear, what this removes is that previously as you navigated through issues we would push them to history so when user popped state (clicked to go back a page) it would load the previous issue.