### PR TITLE
feat: fix auth double render

### DIFF
--- a/src/home/authentication.ts
+++ b/src/home/authentication.ts
@@ -11,13 +11,14 @@ export async function authentication() {
     return;
   }
 
+  const accessToken = getGitHubAccessToken();
+  if (!accessToken) {
+    renderGitHubLoginButton();
+  }
+
   const gitHubUser: null | GitHubUser = await getGitHubUser();
   if (gitHubUser) {
     await trackReferralCode();
     await displayGitHubUserInformation(gitHubUser);
-  }
-  const accessToken = await getGitHubAccessToken();
-  if (!accessToken) {
-    renderGitHubLoginButton();
   }
 }

--- a/src/home/authentication.ts
+++ b/src/home/authentication.ts
@@ -11,7 +11,7 @@ export async function authentication() {
     return;
   }
 
-  const accessToken = getGitHubAccessToken();
+  const accessToken = await getGitHubAccessToken();
   if (!accessToken) {
     renderGitHubLoginButton();
   }


### PR DESCRIPTION
Resolves #161 

```
const gitHubUser: null | GitHubUser = await getGitHubUser();
  if (gitHubUser) {
    await trackReferralCode();
    await displayGitHubUserInformation(gitHubUser);
  }

  const accessToken = getGitHubAccessToken();
  if (!accessToken) {
    renderGitHubLoginButton();
  }
```

The problem with this code order is that `getGitHubAccessToken()` is the function that checks and clears expired tokens. Therefore GitHub user info is shown, and only afterwards we check if expired and show login button. To reproduce the error you can simply change accessToken to null:

```
 const accessToken = null;
```

Though I'd like to simplify auth sometime it's quicker to just switch the order back into correct place. I think we should increase our token expiry date though, 60 mins seems very short.

Here is the reproduced bug with a null accessToken:

https://github.com/user-attachments/assets/40a9a879-bbc4-4784-b45a-837e3c1e4e7c

To QA this solution one can comment the following lines

```
//  if (accessToken) {
//    return accessToken;
//  }
```
  
in `getGitHubAccessToken()`:

https://github.com/ubiquity/work.ubq.fi/blob/bd41261088d2194c70602a18bdb5323cc83dee7c/src/home/getters/get-github-access-token.ts#L29-L47

and run with a clean cache. Whenever you login, GitHub info will never be shown.