### PR TITLE
feat: fix logo

### DIFF
--- a/static/style/inverted-style.css
+++ b/static/style/inverted-style.css
@@ -11,7 +11,7 @@
   #logo {
     border-radius: 6px;
     height: 28px;
-    width: 24.469px;
+    width: 28px;
     margin-right: 8px;
     object-fit: contain;
     vertical-align: middle;

--- a/static/style/style.css
+++ b/static/style/style.css
@@ -11,7 +11,7 @@
   #logo {
     border-radius: 6px;
     height: 28px;
-    width: 24.469px;
+    width: 28px;
     margin-right: 8px;
     object-fit: contain;
     vertical-align: middle;


### PR DESCRIPTION
the following happens cause the logo proportion wasnt 1:1 

```css
 height: 28px;
 width: 24.469px;
```

1. before

<img width="707" alt="image" src="https://github.com/user-attachments/assets/bf2e1020-84fb-42de-9f05-7801c8e1ada8" />

2. after

<img width="726" alt="image" src="https://github.com/user-attachments/assets/4913dccc-ee1b-4467-8689-1cbe69ffd41e" />

it doesnt seem to break the logo, but please look at it carefully:

1. before
<img width="716" alt="image" src="https://github.com/user-attachments/assets/7650bf62-eb88-4f26-be38-c161a157c83f" />

2. after
<img width="727" alt="image" src="https://github.com/user-attachments/assets/4b69971f-8c74-4cb2-b1b8-0c588d2c1fa5" />

