### PR TITLE
[codex] migrate Deno Deploy to Deno 2

### DIFF
--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@codex
+    uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@main
     with:
       project: work-ubq-fi
       deploy_platform: deno2

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -2,29 +2,196 @@ name: Deno Deploy
 
 on:
   push:
-  pull_request:
+    branches-ignore:
+      - dist/**
   workflow_dispatch:
+  delete:
 
 jobs:
-  deploy:
-    uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@main
-    with:
-      project: work-ubq-fi
-      entrypoint: server.ts
-      build_command: deno task build
-      build_env: |
-        SUPABASE_URL=${{ vars.SUPABASE_URL }}
-        SUPABASE_ANON_KEY=${{ vars.SUPABASE_ANON_KEY }}
-      runtime_env: |
-        STATIC_DIR=static
-      include: |
-        server.ts
-        deno.json
-        functions/**
-        static/**
-      debug_fetch_fail: true
-      required_env: |
-        DENO_DEPLOY_TOKEN
-        SUPABASE_URL
-        SUPABASE_ANON_KEY
-    secrets: inherit
+  provision:
+    if: github.event_name != 'delete'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Build static assets
+        env:
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY }}
+        run: deno task build
+
+      - name: Fetch Deno deploy helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone --depth=1 https://github.com/ubiquity-os/deno-deploy.git "$RUNNER_TEMP/deno-deploy-action"
+
+      - name: Resolve Deno app slug
+        id: deploy-target
+        shell: bash
+        env:
+          BASE_APP: work-ubq-fi
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          slugify() {
+            local value="$1"
+            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+            printf '%s' "$value"
+          }
+
+          trim_slug() {
+            local value="$1"
+            local limit="$2"
+            if [ "${#value}" -gt "$limit" ]; then
+              value="${value:0:$limit}"
+            fi
+            value="$(printf '%s' "$value" | sed -E 's/-+$//')"
+            printf '%s' "$value"
+          }
+
+          app_slug="$BASE_APP"
+          if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+            suffix="$(slugify "$REF_NAME")"
+            if [ -z "$suffix" ]; then
+              suffix="branch"
+            fi
+            suffix_budget=$((32 - ${#BASE_APP} - 1))
+            if [ "$suffix_budget" -gt 25 ]; then
+              suffix_budget=25
+            fi
+            if [ "$suffix_budget" -lt 1 ]; then
+              suffix_budget=1
+            fi
+            suffix="$(trim_slug "$suffix" "$suffix_budget")"
+            if [ -z "$suffix" ]; then
+              suffix="b"
+            fi
+            app_slug="${BASE_APP}-${suffix}"
+          fi
+
+          echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
+
+      - name: Provision Deno app
+        shell: bash
+        env:
+          DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          action_path="$RUNNER_TEMP/deno-deploy-action"
+          runtime_env_file="$RUNNER_TEMP/work-runtime.env"
+          printf 'STATIC_DIR=static\n' > "$runtime_env_file"
+
+          deno run \
+            --allow-env \
+            --allow-sys=osRelease \
+            --allow-read="$action_path,$runtime_env_file,$GITHUB_WORKSPACE,/proc/version,/proc/sys/fs/binfmt_misc/WSLInterop,/run/WSL" \
+            --allow-write="$GITHUB_WORKSPACE,$GITHUB_OUTPUT${GITHUB_STEP_SUMMARY:+,$GITHUB_STEP_SUMMARY}" \
+            --allow-run=git,deno \
+            --allow-net=api.deno.com,api.github.com,console.deno.com \
+            "$action_path/scripts/provision.js" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --env-file "$runtime_env_file" \
+            --token "$DENO_DEPLOY_TOKEN" \
+            --organization ubiquity-dao \
+            --github-owner "${GITHUB_REPOSITORY_OWNER}" \
+            --github-repo "${GITHUB_REPOSITORY#*/}" \
+            --github-token "$GITHUB_TOKEN" \
+            --ref-name "${GITHUB_REF_NAME}" \
+            --default-branch "${{ github.event.repository.default_branch }}" \
+            --app "${{ steps.deploy-target.outputs.app_slug }}" \
+            --entrypoint server.ts \
+            --build-manifest=false
+
+  delete-branch-app:
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && github.event.ref != github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Fetch Deno deploy helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone --depth=1 https://github.com/ubiquity-os/deno-deploy.git "$RUNNER_TEMP/deno-deploy-action"
+
+      - name: Resolve Deno app slug
+        id: delete-target
+        shell: bash
+        env:
+          BASE_APP: work-ubq-fi
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DELETED_REF: ${{ github.event.ref }}
+        run: |
+          set -euo pipefail
+
+          slugify() {
+            local value="$1"
+            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+            printf '%s' "$value"
+          }
+
+          trim_slug() {
+            local value="$1"
+            local limit="$2"
+            if [ "${#value}" -gt "$limit" ]; then
+              value="${value:0:$limit}"
+            fi
+            value="$(printf '%s' "$value" | sed -E 's/-+$//')"
+            printf '%s' "$value"
+          }
+
+          app_slug="$BASE_APP"
+          if [ "$DELETED_REF" != "$DEFAULT_BRANCH" ]; then
+            suffix="$(slugify "$DELETED_REF")"
+            if [ -z "$suffix" ]; then
+              suffix="branch"
+            fi
+            suffix_budget=$((32 - ${#BASE_APP} - 1))
+            if [ "$suffix_budget" -gt 25 ]; then
+              suffix_budget=25
+            fi
+            if [ "$suffix_budget" -lt 1 ]; then
+              suffix_budget=1
+            fi
+            suffix="$(trim_slug "$suffix" "$suffix_budget")"
+            if [ -z "$suffix" ]; then
+              suffix="b"
+            fi
+            app_slug="${BASE_APP}-${suffix}"
+          fi
+
+          echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
+
+      - name: Delete Deno branch app
+        shell: bash
+        env:
+          DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          action_path="$RUNNER_TEMP/deno-deploy-action"
+          deno run \
+            --allow-env \
+            --allow-read="$action_path" \
+            --allow-net=api.deno.com,api.github.com \
+            "$action_path/scripts/delete_dist_branch.js" \
+            --token "$DENO_DEPLOY_TOKEN" \
+            --github-owner "${GITHUB_REPOSITORY_OWNER}" \
+            --github-repo "${GITHUB_REPOSITORY#*/}" \
+            --github-token "$GITHUB_TOKEN" \
+            --artifact-ref "dist/${{ github.event.ref }}" \
+            --app "${{ steps.delete-target.outputs.app_slug }}"

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches-ignore:
       - dist/**
+    tags-ignore:
+      - "**"
   workflow_dispatch:
   delete:
 
@@ -58,25 +60,47 @@ jobs:
             printf '%s' "$value"
           }
 
-          app_slug="$BASE_APP"
-          if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
-            suffix="$(slugify "$REF_NAME")"
-            if [ -z "$suffix" ]; then
-              suffix="branch"
+          resolve_app_slug() {
+            local ref_name="$1"
+            local app_slug="$BASE_APP"
+            if [ "$ref_name" != "$DEFAULT_BRANCH" ]; then
+              local suffix
+              suffix="$(slugify "$ref_name")"
+              if [ -z "$suffix" ]; then
+                suffix="branch"
+              fi
+              local suffix_budget
+              suffix_budget=$((32 - ${#BASE_APP} - 1))
+              if [ "$suffix_budget" -gt 25 ]; then
+                suffix_budget=25
+              fi
+              if [ "$suffix_budget" -lt 1 ]; then
+                suffix_budget=1
+              fi
+              local suffix_hash
+              suffix_hash="$(printf '%s' "$ref_name" | sha256sum | cut -c1-8)"
+              if [ "$suffix_budget" -le 8 ]; then
+                suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
+              else
+                local suffix_head_budget
+                suffix_head_budget=$((suffix_budget - 9))
+                local suffix_head
+                suffix_head="$(trim_slug "$suffix" "$suffix_head_budget")"
+                if [ -z "$suffix_head" ]; then
+                  suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
+                else
+                  suffix="$suffix_head-$suffix_hash"
+                fi
+              fi
+              if [ -z "$suffix" ]; then
+                suffix="b"
+              fi
+              app_slug="$BASE_APP-$suffix"
             fi
-            suffix_budget=$((32 - ${#BASE_APP} - 1))
-            if [ "$suffix_budget" -gt 25 ]; then
-              suffix_budget=25
-            fi
-            if [ "$suffix_budget" -lt 1 ]; then
-              suffix_budget=1
-            fi
-            suffix="$(trim_slug "$suffix" "$suffix_budget")"
-            if [ -z "$suffix" ]; then
-              suffix="b"
-            fi
-            app_slug="${BASE_APP}-${suffix}"
-          fi
+            printf '%s' "$app_slug"
+          }
+
+          app_slug="$(resolve_app_slug "$REF_NAME")"
 
           echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
 
@@ -85,11 +109,32 @@ jobs:
         env:
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STATIC_DIR: static
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY || vars.SUPABASE_KEY || '' }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || vars.SUPABASE_SERVICE_ROLE_KEY || '' }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL || vars.SUPABASE_URL || '' }}
+          VOYAGEAI_API_KEY: ${{ secrets.VOYAGEAI_API_KEY || vars.VOYAGEAI_API_KEY || '' }}
         run: |
           set -euo pipefail
           action_path="$RUNNER_TEMP/deno-deploy-action"
           runtime_env_file="$RUNNER_TEMP/work-runtime.env"
-          printf 'STATIC_DIR=static\n' > "$runtime_env_file"
+
+          RUNTIME_ENV_FILE="$runtime_env_file" deno eval '
+            const keys = ["STATIC_DIR", "SUPABASE_URL", "SUPABASE_KEY", "SUPABASE_SERVICE_ROLE_KEY", "VOYAGEAI_API_KEY"];
+            const file = Deno.env.get("RUNTIME_ENV_FILE");
+            if (!file) {
+              throw new Error("RUNTIME_ENV_FILE is required");
+            }
+            const lines = [];
+            for (const key of keys) {
+              const value = Deno.env.get(key)?.trim();
+              if (!value) {
+                continue;
+              }
+              lines.push(`${key}=${JSON.stringify(value)}`);
+            }
+            await Deno.writeTextFile(file, lines.join("\n") + (lines.length ? "\n" : ""));
+          '
 
           deno run \
             --allow-env \
@@ -113,7 +158,7 @@ jobs:
             --build-manifest=false
 
   delete-branch-app:
-    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && github.event.ref != github.event.repository.default_branch
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && !startsWith(github.event.ref, 'dist/') && github.event.ref != github.event.repository.default_branch
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -154,25 +199,47 @@ jobs:
             printf '%s' "$value"
           }
 
-          app_slug="$BASE_APP"
-          if [ "$DELETED_REF" != "$DEFAULT_BRANCH" ]; then
-            suffix="$(slugify "$DELETED_REF")"
-            if [ -z "$suffix" ]; then
-              suffix="branch"
+          resolve_app_slug() {
+            local ref_name="$1"
+            local app_slug="$BASE_APP"
+            if [ "$ref_name" != "$DEFAULT_BRANCH" ]; then
+              local suffix
+              suffix="$(slugify "$ref_name")"
+              if [ -z "$suffix" ]; then
+                suffix="branch"
+              fi
+              local suffix_budget
+              suffix_budget=$((32 - ${#BASE_APP} - 1))
+              if [ "$suffix_budget" -gt 25 ]; then
+                suffix_budget=25
+              fi
+              if [ "$suffix_budget" -lt 1 ]; then
+                suffix_budget=1
+              fi
+              local suffix_hash
+              suffix_hash="$(printf '%s' "$ref_name" | sha256sum | cut -c1-8)"
+              if [ "$suffix_budget" -le 8 ]; then
+                suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
+              else
+                local suffix_head_budget
+                suffix_head_budget=$((suffix_budget - 9))
+                local suffix_head
+                suffix_head="$(trim_slug "$suffix" "$suffix_head_budget")"
+                if [ -z "$suffix_head" ]; then
+                  suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
+                else
+                  suffix="$suffix_head-$suffix_hash"
+                fi
+              fi
+              if [ -z "$suffix" ]; then
+                suffix="b"
+              fi
+              app_slug="$BASE_APP-$suffix"
             fi
-            suffix_budget=$((32 - ${#BASE_APP} - 1))
-            if [ "$suffix_budget" -gt 25 ]; then
-              suffix_budget=25
-            fi
-            if [ "$suffix_budget" -lt 1 ]; then
-              suffix_budget=1
-            fi
-            suffix="$(trim_slug "$suffix" "$suffix_budget")"
-            if [ -z "$suffix" ]; then
-              suffix="b"
-            fi
-            app_slug="${BASE_APP}-${suffix}"
-          fi
+            printf '%s' "$app_slug"
+          }
+
+          app_slug="$(resolve_app_slug "$DELETED_REF")"
 
           echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -7,258 +7,33 @@ on:
     tags-ignore:
       - "**"
   workflow_dispatch:
-  delete:
 
 jobs:
-  provision:
-    if: github.event_name != 'delete'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Build static assets
-        env:
-          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY }}
-        run: deno task build
-
-      - name: Fetch Deno deploy helper
-        shell: bash
-        run: |
-          set -euo pipefail
-          git clone --depth=1 https://github.com/ubiquity-os/deno-deploy.git "$RUNNER_TEMP/deno-deploy-action"
-
-      - name: Resolve Deno app slug
-        id: deploy-target
-        shell: bash
-        env:
-          BASE_APP: work-ubq-fi
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          slugify() {
-            local value="$1"
-            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
-            printf '%s' "$value"
-          }
-
-          trim_slug() {
-            local value="$1"
-            local limit="$2"
-            if [ "${#value}" -gt "$limit" ]; then
-              value="${value:0:$limit}"
-            fi
-            value="$(printf '%s' "$value" | sed -E 's/-+$//')"
-            printf '%s' "$value"
-          }
-
-          resolve_app_slug() {
-            local ref_name="$1"
-            local app_slug="$BASE_APP"
-            if [ "$ref_name" != "$DEFAULT_BRANCH" ]; then
-              local suffix
-              suffix="$(slugify "$ref_name")"
-              if [ -z "$suffix" ]; then
-                suffix="branch"
-              fi
-              local suffix_budget
-              suffix_budget=$((32 - ${#BASE_APP} - 1))
-              if [ "$suffix_budget" -gt 25 ]; then
-                suffix_budget=25
-              fi
-              if [ "$suffix_budget" -lt 1 ]; then
-                suffix_budget=1
-              fi
-              local suffix_hash
-              suffix_hash="$(printf '%s' "$ref_name" | sha256sum | cut -c1-8)"
-              if [ "$suffix_budget" -le 8 ]; then
-                suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
-              else
-                local suffix_head_budget
-                suffix_head_budget=$((suffix_budget - 9))
-                local suffix_head
-                suffix_head="$(trim_slug "$suffix" "$suffix_head_budget")"
-                if [ -z "$suffix_head" ]; then
-                  suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
-                else
-                  suffix="$suffix_head-$suffix_hash"
-                fi
-              fi
-              if [ -z "$suffix" ]; then
-                suffix="b"
-              fi
-              app_slug="$BASE_APP-$suffix"
-            fi
-            printf '%s' "$app_slug"
-          }
-
-          app_slug="$(resolve_app_slug "$REF_NAME")"
-
-          echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
-
-      - name: Provision Deno app
-        shell: bash
-        env:
-          DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          STATIC_DIR: static
-          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY || vars.SUPABASE_KEY || '' }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || vars.SUPABASE_SERVICE_ROLE_KEY || '' }}
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL || vars.SUPABASE_URL || '' }}
-          VOYAGEAI_API_KEY: ${{ secrets.VOYAGEAI_API_KEY || vars.VOYAGEAI_API_KEY || '' }}
-        run: |
-          set -euo pipefail
-          action_path="$RUNNER_TEMP/deno-deploy-action"
-          runtime_env_file="$RUNNER_TEMP/work-runtime.env"
-
-          RUNTIME_ENV_FILE="$runtime_env_file" deno eval '
-            const keys = ["STATIC_DIR", "SUPABASE_URL", "SUPABASE_KEY", "SUPABASE_SERVICE_ROLE_KEY", "VOYAGEAI_API_KEY"];
-            const file = Deno.env.get("RUNTIME_ENV_FILE");
-            if (!file) {
-              throw new Error("RUNTIME_ENV_FILE is required");
-            }
-            const lines = [];
-            for (const key of keys) {
-              const value = Deno.env.get(key)?.trim();
-              if (!value) {
-                continue;
-              }
-              lines.push(`${key}=${JSON.stringify(value)}`);
-            }
-            await Deno.writeTextFile(file, lines.join("\n") + (lines.length ? "\n" : ""));
-          '
-
-          deno run \
-            --allow-env \
-            --allow-sys=osRelease \
-            --allow-read="$action_path,$runtime_env_file,$GITHUB_WORKSPACE,/proc/version,/proc/sys/fs/binfmt_misc/WSLInterop,/run/WSL" \
-            --allow-write="$GITHUB_WORKSPACE,$GITHUB_OUTPUT${GITHUB_STEP_SUMMARY:+,$GITHUB_STEP_SUMMARY}" \
-            --allow-run=git,deno \
-            --allow-net=api.deno.com,api.github.com,console.deno.com \
-            "$action_path/scripts/provision.js" \
-            --repo-root "$GITHUB_WORKSPACE" \
-            --env-file "$runtime_env_file" \
-            --token "$DENO_DEPLOY_TOKEN" \
-            --organization ubiquity-dao \
-            --github-owner "${GITHUB_REPOSITORY_OWNER}" \
-            --github-repo "${GITHUB_REPOSITORY#*/}" \
-            --github-token "$GITHUB_TOKEN" \
-            --ref-name "${GITHUB_REF_NAME}" \
-            --default-branch "${{ github.event.repository.default_branch }}" \
-            --app "${{ steps.deploy-target.outputs.app_slug }}" \
-            --entrypoint server.ts \
-            --build-manifest=false
-
-  delete-branch-app:
-    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && !startsWith(github.event.ref, 'dist/') && github.event.ref != github.event.repository.default_branch
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Fetch Deno deploy helper
-        shell: bash
-        run: |
-          set -euo pipefail
-          git clone --depth=1 https://github.com/ubiquity-os/deno-deploy.git "$RUNNER_TEMP/deno-deploy-action"
-
-      - name: Resolve Deno app slug
-        id: delete-target
-        shell: bash
-        env:
-          BASE_APP: work-ubq-fi
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          DELETED_REF: ${{ github.event.ref }}
-        run: |
-          set -euo pipefail
-
-          slugify() {
-            local value="$1"
-            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
-            printf '%s' "$value"
-          }
-
-          trim_slug() {
-            local value="$1"
-            local limit="$2"
-            if [ "${#value}" -gt "$limit" ]; then
-              value="${value:0:$limit}"
-            fi
-            value="$(printf '%s' "$value" | sed -E 's/-+$//')"
-            printf '%s' "$value"
-          }
-
-          resolve_app_slug() {
-            local ref_name="$1"
-            local app_slug="$BASE_APP"
-            if [ "$ref_name" != "$DEFAULT_BRANCH" ]; then
-              local suffix
-              suffix="$(slugify "$ref_name")"
-              if [ -z "$suffix" ]; then
-                suffix="branch"
-              fi
-              local suffix_budget
-              suffix_budget=$((32 - ${#BASE_APP} - 1))
-              if [ "$suffix_budget" -gt 25 ]; then
-                suffix_budget=25
-              fi
-              if [ "$suffix_budget" -lt 1 ]; then
-                suffix_budget=1
-              fi
-              local suffix_hash
-              suffix_hash="$(printf '%s' "$ref_name" | sha256sum | cut -c1-8)"
-              if [ "$suffix_budget" -le 8 ]; then
-                suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
-              else
-                local suffix_head_budget
-                suffix_head_budget=$((suffix_budget - 9))
-                local suffix_head
-                suffix_head="$(trim_slug "$suffix" "$suffix_head_budget")"
-                if [ -z "$suffix_head" ]; then
-                  suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
-                else
-                  suffix="$suffix_head-$suffix_hash"
-                fi
-              fi
-              if [ -z "$suffix" ]; then
-                suffix="b"
-              fi
-              app_slug="$BASE_APP-$suffix"
-            fi
-            printf '%s' "$app_slug"
-          }
-
-          app_slug="$(resolve_app_slug "$DELETED_REF")"
-
-          echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
-
-      - name: Delete Deno branch app
-        shell: bash
-        env:
-          DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          action_path="$RUNNER_TEMP/deno-deploy-action"
-          deno run \
-            --allow-env \
-            --allow-read="$action_path" \
-            --allow-net=api.deno.com,api.github.com \
-            "$action_path/scripts/delete_dist_branch.js" \
-            --token "$DENO_DEPLOY_TOKEN" \
-            --github-owner "${GITHUB_REPOSITORY_OWNER}" \
-            --github-repo "${GITHUB_REPOSITORY#*/}" \
-            --github-token "$GITHUB_TOKEN" \
-            --artifact-ref "dist/${{ github.event.ref }}" \
-            --app "${{ steps.delete-target.outputs.app_slug }}"
+  deploy:
+    uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@codex/deno-2-programmatic
+    with:
+      project: work-ubq-fi
+      deploy_platform: deno2
+      entrypoint: server.ts
+      install_command: deno install
+      build_command: deno task build
+      build_env: |
+        SUPABASE_URL=$SUPABASE_URL
+        SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+      runtime_env: |
+        STATIC_DIR=static
+        SUPABASE_URL=$SUPABASE_URL
+        SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+        SUPABASE_SERVICE_ROLE_KEY=$SUPABASE_SERVICE_ROLE_KEY
+        SUPABASE_KEY=$SUPABASE_SERVICE_ROLE_KEY
+      debug_fetch_paths: |
+        /
+        /dist/home.js
+        /style/inverted-style.css
+        /favicon.png
+      debug_fetch_fail: true
+      required_env: |
+        DENO_DEPLOY_TOKEN
+        SUPABASE_URL
+        SUPABASE_ANON_KEY
+    secrets: inherit

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@codex/deno-2-programmatic
+    uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@codex
     with:
       project: work-ubq-fi
       deploy_platform: deno2

--- a/.github/workflows/deno-tasks.yml
+++ b/.github/workflows/deno-tasks.yml
@@ -58,13 +58,13 @@ jobs:
               curl -fsS --retry 5 --retry-connrefused -H 'Accept: text/html' "$BASE/" >/dev/null
 
               echo "Curl dist JS (bundled app)"
-              curl -fsS --retry 5 --retry-connrefused "$BASE/dist/src/home/home.js" >/dev/null
+              curl -fsS --retry 5 --retry-connrefused "$BASE/dist/home.js" >/dev/null
 
               echo "Curl CSS (inverted stylesheet)"
               curl -fsS --retry 5 --retry-connrefused "$BASE/style/inverted-style.css" >/dev/null
 
               echo "Curl favicon"
-              curl -fsS --retry 5 --retry-connrefused -I "$BASE/favicon.svg" >/dev/null
+              curl -fsS --retry 5 --retry-connrefused -I "$BASE/favicon.png" >/dev/null
 
               echo "Shutting down server (pid=$srv_pid)"
               kill -TERM "$srv_pid" || true

--- a/build/esbuild-build.ts
+++ b/build/esbuild-build.ts
@@ -64,7 +64,7 @@ async function flattenHomeBundle() {
   }
   await Deno.mkdir("static/dist", { recursive: true });
   await Deno.copyFile(sourceBundle, targetBundle);
-  // Drop the nested directory so deployctl only sees file assets (avoid '/src' upload errors).
+  // Drop the nested directory so Deno Deploy only sees file assets (avoid '/src' upload errors).
   await Deno.remove("static/dist/src", { recursive: true });
 }
 


### PR DESCRIPTION
## Summary
- migrate deploys to the shared Deno Deploy reusable workflow at `ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@codex/deno-2-programmatic`
- set `deploy_platform: deno2` for `.deno.net` deploys while keeping the existing `work-ubq-fi` project name and `server.ts` entrypoint
- use Deno-native deploy commands: `deno install` and `deno task build`
- keep `DENO_DEPLOY_TOKEN` and existing Supabase runtime/build env names; no new env vars are introduced
- fix CI smoke-test asset paths for the flattened `static/dist/home.js` output and existing `favicon.png`

## Validation
Local checks on `cd66937`:
- `deno install`
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=anon_key_for_ci deno task verify`
  - build passed
  - ESLint passed with two existing warnings in server smoke tests
  - Prettier check passed
  - cspell passed
  - knip passed
  - Deno tests passed: 27 passed, 0 failed

Remote checks on `cd66937`:
- Conventional Commits: passed
- Deno Tasks CI: passed (`build`, `check`, `cspell`, `knip`, `serve-smoke`, `test`)
- Deno Deploy: blocked in `Ensure project exists and sync secrets`

## Blocker
Deno Deploy failed before publishing an endpoint because the Deno 2 CLI rejected the existing repo secret:

```text
The token specified via 'DENO_DEPLOY_TOKEN' or the '--token' flag is invalid.
```

Per the migration playbook, this should be fixed by updating the existing repo-level `DENO_DEPLOY_TOKEN` value to a Deno 2-compatible token. No new secret/env var should be added.

## Endpoint
- Not available yet; the workflow failed before emitting a `.deno.net` URL.

## Notes
- This intentionally points at the shared workflow PR branch until `ubiquity/deno-deploy-workflow#18` is merged.