### PR TITLE
feat: add local match ranking

### DIFF
--- a/functions/issue-scraper.ts
+++ b/functions/issue-scraper.ts
@@ -427,6 +427,7 @@ async function issueScraper(username: string, supabase: SupabaseClient, voyageAp
           id: issue.id,
           markdown: issue.markdown,
           plaintext: issue.plaintext,
+          repository: issue.payload.repository.full_name,
         })),
         storageFailed: storageFailed,
       },

--- a/src/home/matching/developer-profile.ts
+++ b/src/home/matching/developer-profile.ts
@@ -1,0 +1,109 @@
+export const MATCH_PROFILE_STORAGE_KEY = "devpoolMatchProfile";
+
+export interface DeveloperMatchProfile {
+  terms: string[];
+  repositories: string[];
+  updatedAt: number;
+}
+
+export interface ScrapedIssueProfileSource {
+  markdown?: string | null;
+  plaintext?: string | null;
+  repository?: string | null;
+}
+
+const STOP_WORDS = new Set([
+  "about",
+  "after",
+  "again",
+  "against",
+  "also",
+  "because",
+  "before",
+  "being",
+  "between",
+  "could",
+  "for",
+  "from",
+  "have",
+  "into",
+  "issue",
+  "make",
+  "more",
+  "only",
+  "should",
+  "task",
+  "that",
+  "their",
+  "there",
+  "these",
+  "this",
+  "through",
+  "with",
+  "would",
+]);
+
+export function buildDeveloperMatchProfile(issues: ScrapedIssueProfileSource[], updatedAt = Date.now()): DeveloperMatchProfile {
+  const termCounts = new Map<string, number>();
+  const repositories = new Set<string>();
+
+  for (const issue of issues) {
+    const repository = issue.repository?.trim().toLowerCase();
+    if (repository) repositories.add(repository);
+
+    const text = [issue.plaintext, issue.markdown].filter(Boolean).join(" ");
+    for (const term of tokenizeProfileText(text)) {
+      termCounts.set(term, (termCounts.get(term) ?? 0) + 1);
+    }
+  }
+
+  const terms = [...termCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 40)
+    .map(([term]) => term);
+
+  return {
+    terms,
+    repositories: [...repositories].sort(),
+    updatedAt,
+  };
+}
+
+export function saveDeveloperMatchProfile(profile: DeveloperMatchProfile, storage = getBrowserStorage()) {
+  if (!storage || profile.terms.length === 0) return;
+  storage.setItem(MATCH_PROFILE_STORAGE_KEY, JSON.stringify(profile));
+}
+
+export function loadDeveloperMatchProfile(storage = getBrowserStorage()): DeveloperMatchProfile | null {
+  if (!storage) return null;
+
+  try {
+    const raw = storage.getItem(MATCH_PROFILE_STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed?.terms)) return null;
+
+    return {
+      terms: parsed.terms.filter((term: unknown): term is string => typeof term === "string"),
+      repositories: Array.isArray(parsed.repositories) ? parsed.repositories.filter((repo: unknown): repo is string => typeof repo === "string") : [],
+      updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function tokenizeProfileText(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/[^a-z0-9#+.\s-]/g, " ")
+    .split(/\s+/)
+    .map((term) => term.replace(/^-+|-+$/g, ""))
+    .filter((term) => term.length > 2 && !STOP_WORDS.has(term) && !/^\d+$/.test(term));
+}
+
+function getBrowserStorage(): Storage | null {
+  return typeof globalThis.localStorage === "undefined" ? null : globalThis.localStorage;
+}

--- a/src/home/matching/developer-profile.ts
+++ b/src/home/matching/developer-profile.ts
@@ -1,4 +1,4 @@
-export const MATCH_PROFILE_STORAGE_KEY = "devpoolMatchProfile";
+const MATCH_PROFILE_STORAGE_KEY = "devpoolMatchProfile";
 
 export interface DeveloperMatchProfile {
   terms: string[];

--- a/src/home/matching/sort-issues-by-match.ts
+++ b/src/home/matching/sort-issues-by-match.ts
@@ -1,0 +1,77 @@
+import { GitHubIssue, GitHubLabel } from "../github-types.ts";
+import { calculateTimeLabelValue } from "../sorting/calculate-time-label-value.ts";
+import { getLabelText } from "../sorting/label-utils.ts";
+import { DeveloperMatchProfile, loadDeveloperMatchProfile } from "./developer-profile.ts";
+
+export function sortIssuesByMatch(issues: GitHubIssue[], profile: DeveloperMatchProfile | null = loadDeveloperMatchProfile()) {
+  return issues.sort((a, b) => {
+    const scoreDiff = calculateMatchScore(b, profile) - calculateMatchScore(a, profile);
+    if (scoreDiff !== 0) return scoreDiff;
+    return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+  });
+}
+
+export function calculateMatchScore(issue: GitHubIssue, profile: DeveloperMatchProfile | null = loadDeveloperMatchProfile()): number {
+  const profileTerms = new Set(profile?.terms.map((term) => term.toLowerCase()) ?? []);
+  const profileRepositories = new Set(profile?.repositories.map((repo) => repo.toLowerCase()) ?? []);
+
+  return (
+    calculateProfileOverlap(issue, profileTerms) +
+    calculateRepositoryScore(issue, profileRepositories) +
+    calculateOpportunityScore(issue.labels) +
+    calculateActivityScore(issue.updated_at)
+  );
+}
+
+function calculateProfileOverlap(issue: GitHubIssue, profileTerms: Set<string>): number {
+  if (profileTerms.size === 0) return 0;
+
+  const title = issue.title.toLowerCase();
+  const body = (issue.body ?? "").toLowerCase();
+  const labels = issue.labels.map(getLabelText).join(" ").toLowerCase();
+  let score = 0;
+
+  for (const term of profileTerms) {
+    if (title.includes(term)) score += 4;
+    if (labels.includes(term)) score += 2.5;
+    if (body.includes(term)) score += 1;
+  }
+
+  return score;
+}
+
+function calculateRepositoryScore(issue: GitHubIssue, profileRepositories: Set<string>): number {
+  if (profileRepositories.size === 0) return 0;
+
+  const repository = issue.repository_url.split("/").slice(-2).join("/").toLowerCase();
+
+  return profileRepositories.has(repository) ? 6 : 0;
+}
+
+function calculateOpportunityScore(labels: GitHubLabel[]): number {
+  const price = labels.map(getPriceFromLabel).find((value) => value !== null) ?? 0;
+  const priority = labels.map(getPriorityFromLabel).find((value) => value !== null) ?? 0;
+  const time = labels.map(getTimeFromLabel).find((value) => value !== null) ?? 0;
+
+  return Math.log10(price + 1) * 1.5 + priority * 1.25 + (time > 0 ? 1 / time : 0);
+}
+
+function calculateActivityScore(updatedAt: string): number {
+  const ageInDays = (Date.now() - new Date(updatedAt).getTime()) / 86_400_000;
+  return Math.max(0, 2 - ageInDays / 30);
+}
+
+function getPriceFromLabel(label: GitHubLabel): number | null {
+  const match = getLabelText(label).match(/^Price:\s*([\d,]+)/);
+  return match ? parseInt(match[1].replace(/,/g, ""), 10) : null;
+}
+
+function getPriorityFromLabel(label: GitHubLabel): number | null {
+  const match = getLabelText(label).match(/^Priority:\s*(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+function getTimeFromLabel(label: GitHubLabel): number | null {
+  const text = getLabelText(label);
+  return text.startsWith("Time: ") ? calculateTimeLabelValue(text) : null;
+}

--- a/src/home/matching/sort-issues-by-match.ts
+++ b/src/home/matching/sort-issues-by-match.ts
@@ -11,7 +11,7 @@ export function sortIssuesByMatch(issues: GitHubIssue[], profile: DeveloperMatch
   });
 }
 
-export function calculateMatchScore(issue: GitHubIssue, profile: DeveloperMatchProfile | null = loadDeveloperMatchProfile()): number {
+function calculateMatchScore(issue: GitHubIssue, profile: DeveloperMatchProfile | null = loadDeveloperMatchProfile()): number {
   const profileTerms = new Set(profile?.terms.map((term) => term.toLowerCase()) ?? []);
   const profileRepositories = new Set(profile?.repositories.map((repo) => repo.toLowerCase()) ?? []);
 

--- a/src/home/scraper/issue-scraper.ts
+++ b/src/home/scraper/issue-scraper.ts
@@ -1,4 +1,5 @@
 import { checkSupabaseSession } from "../rendering/render-github-login-button.ts";
+import { buildDeveloperMatchProfile, saveDeveloperMatchProfile } from "../matching/developer-profile.ts";
 
 async function fetchWithRetry(input: RequestInfo, init?: RequestInit, retries: number = 3): Promise<Response> {
   for (let i = 0; i < retries; i++) {
@@ -68,6 +69,7 @@ export async function startIssueScraper(username: string) {
 
     if (response.status === 200 && responseData?.success) {
       localStorage.setItem(lastFetchKey, now.toString());
+      saveDeveloperMatchProfile(buildDeveloperMatchProfile(responseData.issues ?? []));
       return JSON.stringify({
         success: true,
         message: "Successfully fetched issues",

--- a/src/home/sorting/generate-sorting-buttons.ts
+++ b/src/home/sorting/generate-sorting-buttons.ts
@@ -1,6 +1,6 @@
 import { SortingManager } from "./sorting-manager";
 
-export const SORTING_OPTIONS = ["price", "time", "priority", "activity"] as const;
+export const SORTING_OPTIONS = ["match", "price", "time", "priority", "activity"] as const;
 export type Sorting = (typeof SORTING_OPTIONS)[number];
 
 export function generateSortingToolbar() {

--- a/src/home/sorting/sort-issues-by.ts
+++ b/src/home/sorting/sort-issues-by.ts
@@ -1,5 +1,6 @@
 import { GitHubIssue } from "../github-types.ts";
 import { SORTING_OPTIONS } from "./generate-sorting-buttons.ts";
+import { sortIssuesByMatch } from "../matching/sort-issues-by-match.ts";
 import { sortIssuesByPrice } from "./sort-issues-by-price.ts";
 import { sortIssuesByPriority } from "./sort-issues-by-priority.ts";
 import { sortIssuesByTime } from "./sort-issues-by-time.ts";
@@ -7,6 +8,8 @@ import { sortIssuesByLatestActivity } from "./sort-issues-by-updated-time.ts";
 
 export function sortIssuesBy(tasks: GitHubIssue[], sortBy: (typeof SORTING_OPTIONS)[number]) {
   switch (sortBy) {
+    case "match":
+      return sortIssuesByMatch(tasks);
     case "priority":
       return sortIssuesByPriority(tasks);
     case "time":

--- a/tests/developer_profile.test.ts
+++ b/tests/developer_profile.test.ts
@@ -1,0 +1,61 @@
+/// <reference lib="deno.ns" />
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildDeveloperMatchProfile,
+  loadDeveloperMatchProfile,
+  MATCH_PROFILE_STORAGE_KEY,
+  saveDeveloperMatchProfile,
+} from "../src/home/matching/developer-profile.ts";
+
+Deno.test("buildDeveloperMatchProfile extracts stable terms from completed issue text", () => {
+  const profile = buildDeveloperMatchProfile(
+    [
+      {
+        plaintext: "Fix Deno routing and Supabase validation for preview deployments",
+        repository: "ubiquity/work.ubq.fi",
+      },
+      {
+        plaintext: "Add deterministic Deno tests for routing fallback behavior",
+      },
+    ],
+    123
+  );
+
+  assertEquals(profile.updatedAt, 123);
+  assertEquals(profile.repositories, ["ubiquity/work.ubq.fi"]);
+  assertEquals(profile.terms.slice(0, 3), ["deno", "routing", "add"]);
+});
+
+Deno.test("saveDeveloperMatchProfile skips empty profiles and loads saved profiles", () => {
+  const storage = new Map<string, string>();
+  const adapter: Storage = {
+    get length() {
+      return storage.size;
+    },
+    clear() {
+      storage.clear();
+    },
+    getItem(key) {
+      return storage.get(key) ?? null;
+    },
+    key(index) {
+      return [...storage.keys()][index] ?? null;
+    },
+    removeItem(key) {
+      storage.delete(key);
+    },
+    setItem(key, value) {
+      storage.set(key, value);
+    },
+  };
+
+  saveDeveloperMatchProfile({ terms: [], repositories: [], updatedAt: 1 }, adapter);
+  assertEquals(adapter.getItem(MATCH_PROFILE_STORAGE_KEY), null);
+
+  saveDeveloperMatchProfile({ terms: ["deno"], repositories: ["ubiquity/work.ubq.fi"], updatedAt: 2 }, adapter);
+  assertEquals(loadDeveloperMatchProfile(adapter), {
+    terms: ["deno"],
+    repositories: ["ubiquity/work.ubq.fi"],
+    updatedAt: 2,
+  });
+});

--- a/tests/developer_profile.test.ts
+++ b/tests/developer_profile.test.ts
@@ -3,7 +3,6 @@ import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
   buildDeveloperMatchProfile,
   loadDeveloperMatchProfile,
-  MATCH_PROFILE_STORAGE_KEY,
   saveDeveloperMatchProfile,
 } from "../src/home/matching/developer-profile.ts";
 
@@ -50,7 +49,7 @@ Deno.test("saveDeveloperMatchProfile skips empty profiles and loads saved profil
   };
 
   saveDeveloperMatchProfile({ terms: [], repositories: [], updatedAt: 1 }, adapter);
-  assertEquals(adapter.getItem(MATCH_PROFILE_STORAGE_KEY), null);
+  assertEquals(storage.size, 0);
 
   saveDeveloperMatchProfile({ terms: ["deno"], repositories: ["ubiquity/work.ubq.fi"], updatedAt: 2 }, adapter);
   assertEquals(loadDeveloperMatchProfile(adapter), {

--- a/tests/sort_issues_by_match.test.ts
+++ b/tests/sort_issues_by_match.test.ts
@@ -1,8 +1,8 @@
 /// <reference lib="deno.ns" />
-import { assertEquals, assertGreater } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import type { GitHubIssue } from "../src/home/github-types.ts";
 import type { DeveloperMatchProfile } from "../src/home/matching/developer-profile.ts";
-import { calculateMatchScore, sortIssuesByMatch } from "../src/home/matching/sort-issues-by-match.ts";
+import { sortIssuesByMatch } from "../src/home/matching/sort-issues-by-match.ts";
 
 function issue(partial: Partial<GitHubIssue> & Pick<GitHubIssue, "number" | "title">): GitHubIssue {
   return {
@@ -24,7 +24,7 @@ const profile: DeveloperMatchProfile = {
   updatedAt: 1,
 };
 
-Deno.test("calculateMatchScore rewards profile terms in task content", () => {
+Deno.test("sortIssuesByMatch rewards profile terms in task content", () => {
   const matching = issue({
     number: 1,
     title: "Add Deno routing fallback",
@@ -38,7 +38,10 @@ Deno.test("calculateMatchScore rewards profile terms in task content", () => {
     labels: ["Price: 450 USD", "Priority: 3 (High)", "Time: <4 Hours"],
   });
 
-  assertGreater(calculateMatchScore(matching, profile), calculateMatchScore(unrelated, profile));
+  assertEquals(
+    sortIssuesByMatch([unrelated, matching], profile).map((item) => item.number),
+    [1, 2]
+  );
 });
 
 Deno.test("sortIssuesByMatch ranks profile matches before higher-price unrelated tasks", () => {

--- a/tests/sort_issues_by_match.test.ts
+++ b/tests/sort_issues_by_match.test.ts
@@ -1,0 +1,80 @@
+/// <reference lib="deno.ns" />
+import { assertEquals, assertGreater } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import type { GitHubIssue } from "../src/home/github-types.ts";
+import type { DeveloperMatchProfile } from "../src/home/matching/developer-profile.ts";
+import { calculateMatchScore, sortIssuesByMatch } from "../src/home/matching/sort-issues-by-match.ts";
+
+function issue(partial: Partial<GitHubIssue> & Pick<GitHubIssue, "number" | "title">): GitHubIssue {
+  return {
+    id: partial.number,
+    node_id: `n${partial.number}`,
+    body: null,
+    labels: [],
+    repository_url: "https://github.com/ubiquity/work.ubq.fi",
+    html_url: "",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-06-01T00:00:00.000Z",
+    ...partial,
+  } as GitHubIssue;
+}
+
+const profile: DeveloperMatchProfile = {
+  terms: ["deno", "routing", "supabase"],
+  repositories: ["ubiquity/work.ubq.fi"],
+  updatedAt: 1,
+};
+
+Deno.test("calculateMatchScore rewards profile terms in task content", () => {
+  const matching = issue({
+    number: 1,
+    title: "Add Deno routing fallback",
+    body: "Supabase login should gracefully recover",
+    labels: ["Price: 450 USD", "Priority: 3 (High)", "Time: <4 Hours"],
+  });
+  const unrelated = issue({
+    number: 2,
+    title: "Polish copy",
+    body: "Small text update",
+    labels: ["Price: 450 USD", "Priority: 3 (High)", "Time: <4 Hours"],
+  });
+
+  assertGreater(calculateMatchScore(matching, profile), calculateMatchScore(unrelated, profile));
+});
+
+Deno.test("sortIssuesByMatch ranks profile matches before higher-price unrelated tasks", () => {
+  const matching = issue({
+    number: 1,
+    title: "Deno routing fallback",
+    labels: ["Price: 150 USD", "Priority: 2 (Medium)", "Time: <2 Hours"],
+  });
+  const expensive = issue({
+    number: 2,
+    title: "Marketing campaign copy",
+    labels: ["Price: 900 USD", "Priority: 3 (High)", "Time: <1 Day"],
+  });
+
+  assertEquals(
+    sortIssuesByMatch([expensive, matching], profile).map((item) => item.number),
+    [1, 2]
+  );
+});
+
+Deno.test("sortIssuesByMatch falls back to opportunity score without profile terms", () => {
+  const highPriority = issue({
+    number: 1,
+    title: "Small urgent task",
+    labels: ["Price: 75 USD", "Priority: 3 (High)", "Time: <1 Hour"],
+    updated_at: "2026-06-01T00:00:00.000Z",
+  });
+  const lowPriority = issue({
+    number: 2,
+    title: "Larger slow task",
+    labels: ["Price: 75 USD", "Priority: 1 (Normal)", "Time: <1 Day"],
+    updated_at: "2026-06-01T00:00:00.000Z",
+  });
+
+  assertEquals(
+    sortIssuesByMatch([lowPriority, highPriority], null).map((item) => item.number),
+    [1, 2]
+  );
+});


### PR DESCRIPTION
## Summary
- Add deterministic local matching data for developer profiles.
- Add a match-based issue sorting strategy that can run without external embedding services.
- Include tests for profile extraction and match sorting behavior.
- Keep implementation-only helpers private so the existing Knip check passes.

## Validation
- `deno task knip`
- `deno test --allow-read --allow-env tests/developer_profile.test.ts tests/sort_issues_by_match.test.ts`
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=dummy deno task build`
- `git diff --check`

Fixes devpool-directory/devpool-directory-tasks#63
/claim devpool-directory/devpool-directory-tasks#63
